### PR TITLE
Refactor tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,33 @@
 [tox]
+
 envlist =
     py35
     py36
+
 [testenv]
+
 deps =
+
     # pytest-mypy 0.3.0 workaround for https://github.com/dbader/pytest-mypy/issues/6
     mypy < 0.570
+
+    # https://github.com/pytest-dev
     flake8-bugbear
     flake8-commas
     flake8-docstrings
     flake8-import-order
     pep8-naming
+    pytest
     pytest-cov
-    pytest-flake8
-    pytest-flakes
-    pytest-mypy
-    # 1.2+ is necessary for Python 3.5 support:
-    pytest-pycodestyle ~= 1.2
-    # 1.3+ is necessary for Python 3.5 support:
-    pytest-pydocstyle ~= 1.3
-    pytest-pylint
     pytest-randomly
+
+    # other
+    pytest-flake8
+    pytest-mypy
+    pytest-pydocstyle
+    pytest-pylint
+
 commands =
     ./setup.py check --metadata --strict
     keysmith --help
-    pytest --cov keysmith --cov-report term-missing --mypy --pylint --codestyle --docstyle --flakes --flake8
+    pytest --cov keysmith --cov-report term-missing --docstyle --flake8 --mypy --pylint


### PR DESCRIPTION
This is modeled after https://github.com/dmtucker/backlog/pull/29.
Test tools should always be current/latest.
Also, there is no need to run pytest-flakes or pytest-codestyle if pytest-flake8 will be run because:
> Flake8 is a wrapper around these tools:
> -  PyFlakes
> -  pycodestyle
> -  Ned Batchelder’s McCabe script

https://github.com/PyCQA/flake8/blob/4d9d325d3cd987795bf4e7bf1a71fb0930716cf3/README.rst#flake8
