### PR TITLE
Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-global-exclude *.py[cod] __pycache__
-include LICENSE
-include keysmith.py


### PR DESCRIPTION
Without it, everything still gets added:
```
david@kahuna:~/Projects/keysmith $ pipenv run setup.py sdist
running sdist
running egg_info
writing keysmith.egg-info/PKG-INFO
writing dependency_links to keysmith.egg-info/dependency_links.txt
writing entry points to keysmith.egg-info/entry_points.txt
writing top-level names to keysmith.egg-info/top_level.txt
reading manifest file 'keysmith.egg-info/SOURCES.txt'
writing manifest file 'keysmith.egg-info/SOURCES.txt'
running check
creating keysmith-2.0.0
creating keysmith-2.0.0/keysmith.egg-info
copying files to keysmith-2.0.0...
copying LICENSE -> keysmith-2.0.0             <---
copying README.rst -> keysmith-2.0.0
copying keysmith.py -> keysmith-2.0.0         <---
copying setup.py -> keysmith-2.0.0
copying keysmith.egg-info/PKG-INFO -> keysmith-2.0.0/keysmith.egg-info
copying keysmith.egg-info/SOURCES.txt -> keysmith-2.0.0/keysmith.egg-info
copying keysmith.egg-info/dependency_links.txt -> keysmith-2.0.0/keysmith.egg-info
copying keysmith.egg-info/entry_points.txt -> keysmith-2.0.0/keysmith.egg-info
copying keysmith.egg-info/top_level.txt -> keysmith-2.0.0/keysmith.egg-info
Writing keysmith-2.0.0/setup.cfg
creating dist
Creating tar archive
removing 'keysmith-2.0.0' (and everything under it)
```