### PR TITLE
Remove pytest-pydocstyle

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,10 @@ deps =
     # other
     pytest-flake8
     pytest-mypy
-    pytest-pydocstyle
     pytest-pylint
 
 commands =
     ./setup.py check --metadata --strict
     python -m keysmith --version
     keysmith --help
-    pytest --cov keysmith --cov-report term-missing --docstyle --flake8 --mypy --pylint {posargs}
+    pytest --cov keysmith --cov-report term-missing --flake8 --mypy --pylint {posargs}


### PR DESCRIPTION
`pytest-pydocstyle` does essentially the same thing as `flake8-docstrings`, but the latter is supported by pytest-dev.