### PR TITLE
Remove a pip workaround

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,6 @@ envlist =
 
 deps =
 
-    # https://github.com/pypa/pip/issues/988
-    # https://github.com/pradyunsg/zazo/issues/8
-    pycodestyle < 2.4.0
-
     # https://github.com/pytest-dev
     pytest
     pytest-cov


### PR DESCRIPTION
This is blocked by https://github.com/pypa/pip/issues/988, but a release of `flake8 > 3.5.0` would probably do the trick.